### PR TITLE
move the check to see if the domain exists before we check for a valid api key

### DIFF
--- a/pages/api/[network]/set-domain.js
+++ b/pages/api/[network]/set-domain.js
@@ -33,6 +33,22 @@ async function handler(req, res) {
     return res.status(400).json({ error: "Invalid ens name" });
   }
 
+  // check if domain exists
+  let domainQuery = await sql`
+    select * 
+    from domain 
+    where 
+      name = ${domainName} 
+        and 
+      network=${network} 
+    limit 1;`;
+
+  if (domainQuery.length == 0) {
+    return res
+      .status(400)
+      .json({ error: "Domain does not exist. Please use /enable-domain." });
+  }
+
   const allowedApi = await checkApiKey(apiKey, domainName);
   if (!allowedApi) {
     return res
@@ -63,15 +79,6 @@ async function handler(req, res) {
     contenthash_raw: rawContenthash || null,
   };
 
-  // check if domain exists
-  let domainQuery = await sql`
-  select * from domain where name = ${domainName} and network=${network} limit 1;`;
-
-  if (domainQuery.length == 0) {
-    return res
-      .status(400)
-      .json({ error: "Domain does not exist. Please use /enable-domain." });
-  }
   //// if Domain exists we update
   // check that domain is owned by user
   const apiQuery = await sql`


### PR DESCRIPTION
As mentioned in #45 we first check the api key and not if the domain is in the DB.

Moving this check up will return the correct error to the user if a domain is yet to be enabled in namestone.

I'd feel more comfortable merging this after we add tests in #42 